### PR TITLE
Resolve undefined reference error

### DIFF
--- a/ftplugin/idris2.vim
+++ b/ftplugin/idris2.vim
@@ -94,7 +94,8 @@ endfunction
 
 function! IdrisReload(q)
   w
-  let tc = system("idris2 --find-ipkg " . expand ('%:p') . " --client ''")
+  let file = expand ('%:p')
+  let tc = system("idris2 --find-ipkg " . file . " --client ''")
   if (! (tc is ""))
     call IWrite(tc)
   else


### PR DESCRIPTION
When attempting to reload before this change I saw:

```
Error detected while processing function IdrisReload:
line    7:
E121: Undefined variable: file
E116: Invalid arguments for function IWrite
Press ENTER or type command to continue
```

Now I see:

```
Successfully reloaded /tmp/Main.idr
Press ENTER or type command to continue
```

I also verified subsequent expression evaluation, `<LocalLeader>e`, is informed by new code changes.