### PR TITLE
Escape the paths passed to idris2

### DIFF
--- a/ftplugin/idris2.vim
+++ b/ftplugin/idris2.vim
@@ -34,7 +34,7 @@ endfunction
 function! s:IdrisCommand(...)
   let idriscmd = shellescape(join(a:000))
 "  echo("idris2 " . expand ('%:p') . " --client " . idriscmd)
-  return system("idris2 --find-ipkg " . expand ('%:p') . " --client " . idriscmd)
+  return system("idris2 --find-ipkg " . shellescape(expand('%:p')) . " --client " . idriscmd)
 endfunction
 
 function! IdrisDocFold(lineNum)
@@ -94,7 +94,7 @@ endfunction
 
 function! IdrisReload(q)
   w
-  let tc = system("idris2 --find-ipkg " . expand ('%:p') . " --client ''")
+  let tc = system("idris2 --find-ipkg " . shellescape(expand('%:p')) . " --client ''")
   if (! (tc is ""))
     call IWrite(tc)
   else


### PR DESCRIPTION
All the commands failed if the file path contains characters that need to be escaped, such as whitespaces. This patch escapes the path passed as argument to the idris2 command.