### PR TITLE
[Fix] E121: Undefined variable: file in IdrisReload

### DIFF
--- a/ftplugin/idris2.vim
+++ b/ftplugin/idris2.vim
@@ -94,7 +94,8 @@ endfunction
 
 function! IdrisReload(q)
   w
-  let tc = system("idris2 --find-ipkg " . shellescape(expand('%:p')) . " --client ''")
+  let file = expand('%:p')
+  let tc = system("idris2 --find-ipkg " . shellescape(file) . " --client ''")
   if (! (tc is ""))
     call IWrite(tc)
   else


### PR DESCRIPTION
When reloading a file that has no matching `*.ipkg`, I get the following error in neovim:
```
Error detected while processing function IdrisReload:
line    7:
E121: Undefined variable: file
E116: Invalid arguments for function IWrite
```
I don't know vimscript, but this fix looks trivial.

[Edit] Just saw this has already been posted - see https://github.com/edwinb/idris2-vim/pull/3#discussion_r426256485