### PR TITLE
Variable `file` was replaced with an expression

### DIFF
--- a/ftplugin/idris2.vim
+++ b/ftplugin/idris2.vim
@@ -99,7 +99,7 @@ function! IdrisReload(q)
     call IWrite(tc)
   else
     if (a:q==0)
-       call IWrite("Successfully reloaded " . file)
+       call IWrite("Successfully reloaded " . expand('%:t'))
     endif
   endif
   return tc


### PR DESCRIPTION
This variable is not set in `idris2-vim`'s files and thus is not always set. Well, maybe, some other stuff can set this appropriately, but when not, you get an error while reloading a file.