### PR TITLE
Fix a bug where 'file' is undefined.

### DIFF
--- a/ftplugin/idris2.vim
+++ b/ftplugin/idris2.vim
@@ -94,7 +94,8 @@ endfunction
 
 function! IdrisReload(q)
   w
-  let tc = system("idris2 --find-ipkg " . shellescape(expand('%:p')) . " --client ''")
+  let file = expand('%:p')
+  let tc = system("idris2 --find-ipkg " . shellescape(file) . " --client ''")
   if (! (tc is ""))
     call IWrite(tc)
   else


### PR DESCRIPTION
https://github.com/edwinb/idris2-vim/pull/2 broke this. The 'file'
binding is used in the 'else' clause below.