### PR TITLE
Option to remove ANSI color codes from response window

### DIFF
--- a/ftplugin/idris2.vim
+++ b/ftplugin/idris2.vim
@@ -84,7 +84,10 @@ function! RemoveColor(str)
 endfunction
 
 function! IWrite(str)
-  let l:str = RemoveColor(a:str)
+  let l:str = a:str
+  if exists("g:idris_disable_ansi_colors") && g:idris_disable_ansi_colors == 1
+    let l:str = RemoveColor(a:str)
+  endif
   if (bufexists("idris-response"))
     let save_cursor = getcurpos()
     b idris-response

--- a/ftplugin/idris2.vim
+++ b/ftplugin/idris2.vim
@@ -60,6 +60,7 @@ function! IdrisResponseWin()
     badd idris-response
     b idris-response
     let g:idris_respwin = "active"
+    setlocal filetype=unix
     set buftype=nofile
     wincmd k
   elseif (bufexists("idris-response") && g:idris_respwin == "hidden")
@@ -78,17 +79,22 @@ function! IdrisShowResponseWin()
   let g:idris_respwin = "active"
 endfunction
 
+function! RemoveColor(str)
+  return substitute(a:str, "\[[0-9;]*m", "", "g")
+endfunction
+
 function! IWrite(str)
+  let l:str = RemoveColor(a:str)
   if (bufexists("idris-response"))
     let save_cursor = getcurpos()
     b idris-response
     %delete
-    let resp = split(a:str, '\n')
+    let resp = split(l:str, '\n')
     call append(1, resp)
     b #
     call setpos('.', save_cursor)
   else
-    echo a:str
+    echo l:str 
   endif
 endfunction
 


### PR DESCRIPTION
Hi,

This pull request adds the option to set
```
let g:idris_disable_ansi_colors = 1
```
in order to remove the escaped ansi color codes from the repl response. I was getting output such as
```
^[[38;5;9;1mError:^[[0m ^[[1mWhile processing right hand side of
```
and this pull request fixes that with a regex substitution. It should be possible to properly render ANSI colors into syntax highlighting by using [AnsiEsc.vim](https://www.vim.org/scripts/script.php?script_id=302), but I have not tried that yet.

In addition, this pull request sets the filetype of the response buffer to unix to suppress syntax highlighting (this happens when you open the response buffer with \i before issuing a command to the repl).

Note: tested on neovim