### PR TITLE
Fix positional error mentioned in #19

### DIFF
--- a/ftplugin/idris2.vim
+++ b/ftplugin/idris2.vim
@@ -35,7 +35,7 @@ function! s:IdrisCommand(...)
   let idriscmd = shellescape(join(a:000))
   " Vim does not support ANSI escape codes natively, so we need to disable
   " automatic colouring
-  return system("idris2 --no-color --find-ipkg " . shellescape(expand('%:p')) . " --client " . idriscmd)
+  return system("idris2 " . shellescape(expand('%:p')) . " --client --no-color --find-ipkg" . idriscmd)
 endfunction
 
 function! IdrisDocFold(lineNum)


### PR DESCRIPTION
Apparently, the ordering of the command arguments was giving issue to some users (me included) as detailed in #19 .
Not sure why this is needed, as the help for idris2 seems to suggest to have `[options] [input file]`, but apparently this is the case. 