### PR TITLE
Refactor and add the TypeAt command

### DIFF
--- a/ftplugin/idris2.vim
+++ b/ftplugin/idris2.vim
@@ -268,6 +268,19 @@ function! IdrisAddClause(proof)
   endif
 endfunction
 
+function! IdrisTypeAt()
+  let cline = line(".")
+  let ccol = col(".")
+
+  let name = s:currentQueryObject()
+
+  let result = s:IdrisCommand(":typeat", cline, ccol, name)
+
+  if (! (result is ""))
+     call IWrite(result)
+  endif
+endfunction
+
 function! IdrisEval()
   let expr = input ("Expression: ")
   let result = s:IdrisCommand(expr)
@@ -293,6 +306,7 @@ nnoremap <buffer> <silent> <LocalLeader>w 0:call IdrisMakeWith()<ENTER>
 nnoremap <buffer> <silent> <LocalLeader>mc :call IdrisMakeCase()<ENTER>
 nnoremap <buffer> <silent> <LocalLeader>i 0:call IdrisResponseWin()<ENTER>
 nnoremap <buffer> <silent> <LocalLeader>h :call IdrisShowDoc()<ENTER>
+nnoremap <buffer> <silent> <LocalLeader>y :call IdrisTypeAt()<ENTER>
 
 menu Idris.Reload <LocalLeader>r
 menu Idris.Show\ Type <LocalLeader>t

--- a/ftplugin/idris2.vim
+++ b/ftplugin/idris2.vim
@@ -41,8 +41,13 @@ function! s:IdrisCommand(...)
   " automatic colouring
   let commandResult =  system("idris2 --no-color --find-ipkg " . shellescape(expand('%:p')) . " --client " . idriscmd)
 
+  " Keep the window in the same place when reading the file
+  let save_view = winsaveview()
+
   " update the file (Idris2 may have modified it)
   e
+
+  call winrestview(save_view)
 
   return commandResult
 endfunction

--- a/ftplugin/idris2.vim
+++ b/ftplugin/idris2.vim
@@ -81,13 +81,23 @@ endfunction
 
 function! IWrite(str)
   if (bufexists("idris-response"))
-    let save_cursor = getcurpos()
+    " Save the cursor and scroll position (as well as some other details)
+    let save_view = winsaveview()
+
+    " Save the user's 'hidden' option so that we can temporarily set it on in
+    " order to preserve the undo history when switching buffers
+    let save_hidden = &hidden
+
+    set hidden
     b idris-response
     %delete
     let resp = split(a:str, '\n')
     call append(1, resp)
     b #
-    call setpos('.', save_cursor)
+
+    " Restore the saved values
+    let &hidden = save_hidden
+    call winrestview(save_view)
   else
     echo a:str
   endif


### PR DESCRIPTION
The refactors were:
- Move writing and updating the file being edited to `s:IdrisCommand` (removes a lot of code duplication)
- Move saving the window view to `IWrite` (this guarantees that the window always returns to it's previous position. The reload command used to save just the cursor position, not the whole window view, and that caused annoyances)

A change made that isn't really a refactor is that now undo still works after issuing a command that updates the `idris-response` buffer. Previously, the process of writing to it made the buffer with the current file be temporarily abandoned, causing the undo history to be lost. The fix is implemented by temporarily overwriting the `hidden` option, making it become a hidden buffer, rather than abandoned. There might be a more straightforward way of implementing this though, suggestions are welcomed.

The implementation of TypeAt is rather simple. I'm not sure about which key would be the best for it though. My initial idea was `<LocalLeader>ta`, `TypeAt`'s initials, but that would make Vim wait for a second keypress before issuing a regular `<LocalLeader>t`, which is rather inconvenient. I settled on `<LocalLeader>y` for lack of anything better.

I'm sorry if I ended up coupling too many unrelated changes into this pull request, i'm kind of still learning how to help with open source. If any changes are necessary just let me know and I'll do my best.