### PR TITLE
Fix bug in IWrite causing Idris to not see changes.

### DIFF
--- a/ftplugin/idris2.vim
+++ b/ftplugin/idris2.vim
@@ -88,6 +88,7 @@ function! IWrite(str)
     call append(1, resp)
     b #
     call setpos('.', save_cursor)
+    w
   else
     echo a:str
   endif


### PR DESCRIPTION
IWrite somehow persisently updates the file without requiring a write
afterwards. This can lead to unexpected behaviour where Idris fails to
recognise that a file has updated and checks the old `.ttc` version
instead of the file containing the change, e.g. a case-split. Adding an
explicit write at the end of `IWrite` seems to fix the problem.